### PR TITLE
Don't break on chunks without imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,9 @@ export default function (options = {}) {
       let dependencies = []
 
       Object.values(bundle).forEach((chunk) => {
-        dependencies = [...dependencies, ...normalizeImportModules(chunk.imports)]
+        if (chunk.imports) {
+          dependencies = [...dependencies, ...normalizeImportModules(chunk.imports)] 
+        }
       })
 
       dependencies = Array.from(new Set([...dependencies, ...additionalDependencies])).sort()


### PR DESCRIPTION
Happens on:

```json
"rollup": "1.26.5",
"rollup-plugin-typescript2": "0.25.2",
```